### PR TITLE
improve calculation of FFT size for fftw speed & drop minumum graph size

### DIFF
--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -43,9 +43,6 @@
 #include "window.h"
 #include "common.h"
 
-#define	MIN_WIDTH	640
-#define	MIN_HEIGHT	480
-
 #define TICK_LEN			6
 #define	BORDER_LINE_WIDTH	1.8
 
@@ -539,6 +536,18 @@ render_to_surface (const RENDER * render, SNDFILE *infile, int samplerate, sf_co
 		height = render->height ;
 		}
 
+	if (width < 1)
+	{	printf ("Error : 'width' parameter must be >= %d\n",
+			render->border ? (int)(LEFT_BORDER + RIGHT_BORDER) + 1 : 1) ;
+		exit (1) ;
+		} ;
+
+	if (height < 1)
+	{	printf ("Error : 'height' parameter must be >= %d\n",
+			render->border ? (int)(TOP_BORDER + BOTTOM_BORDER) + 1 : 1) ;
+		exit (1) ;
+		} ;
+
 	/*
 	** Choose a speclen value that is long enough to represent frequencies
 	** down to 20Hz.
@@ -691,15 +700,6 @@ render_sndfile (const RENDER * render)
 } /* render_sndfile */
 
 static void
-check_int_range (const char * name, int value, int lower, int upper)
-{
-	if (value < lower || value > upper)
-	{	printf ("Error : '%s' parameter must be in range [%d, %d]\n", name, lower, upper) ;
-		exit (1) ;
-		} ;
-} /* check_int_range */
-
-static void
 usage_exit (const char * argv0, int error)
 {
 	const char * progname ;
@@ -769,10 +769,6 @@ main (int argc, char * argv [])
 	render.width = atoi (argv [k + 1]) ;
 	render.height = atoi (argv [k + 2]) ;
 	render.pngfilepath = argv [k + 3] ;
-
-	check_int_range ("width", render.width, MIN_WIDTH, INT_MAX) ;
-	check_int_range ("height", render.height, MIN_HEIGHT, INT_MAX) ;
-
 
 	render.filename = strrchr (render.sndfilepath, '/') ;
 	render.filename = (render.filename != NULL) ? render.filename + 1 : render.sndfilepath ;


### PR DESCRIPTION
Two changes:
1)
sndfile-spectrogram uses fftw_plan_r2r_1d() whose documentation says:
"FFTW is generally best at handling sizes of the form
    2^a 3^b 5^c 7^d 11^e 13^f
where e+f is either 0 or 1, and the other exponents are arbitrary."

Before, it just added 1-32 to the size to make it a multiple of 32,
which is both wrong for speed and always gives you a bigger FFT
than the one you asked for, even if the dimension is already perfect.

This gives the same or the closest valu that is also >= the graph's height.

The resulting speedup is, for 8192 height, a factor of two (62s -> 33s)

2)
The arbitrary minumum of 640x480 graph size is now 1x1
