### PR TITLE
Fixes from te Debian packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore

--- a/src/generate-chirp.c
+++ b/src/generate-chirp.c
@@ -75,7 +75,7 @@ main (int argc, char * argv [])
 			continue ;
 			} ;
 
-		printf ("\nUnknow option '%s'.\n\n", argv [k]) ;
+		printf ("\nUnknown option '%s'.\n\n", argv [k]) ;
 		exit (1) ;
 		} ;
 
@@ -283,7 +283,7 @@ guess_major_format (const char * filename)
 	if (strcasecmp (ext, ".w64") == 0)
 		return SF_FORMAT_W64 ;
 
-	printf ("\nError : Can only generate files with extentions 'wav', 'aifc', 'aiff', 'aif', 'au', 'w64' and 'caf'.\n\n") ;
+	printf ("\nError : Can only generate files with extensions 'wav', 'aifc', 'aiff', 'aif', 'au', 'w64' and 'caf'.\n\n") ;
 	exit (1) ;
 	return 0 ;
 } /* guess_major_format */


### PR DESCRIPTION
while preparing the Debian package for sndfile-tools, i came upon a few minor issues:

- some spelling mistakes
- repository configuration in the release-tarballs

this PR fixes both.
the spelling-mistakes are trivial.
the repostiory configuration is an issue if a downstream (like Debian) uses git for packaging, in which case things like `.gitignore` are just annoying.