### PR TITLE
Autotools cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ sndfile-tools-*.tar.bz2
 tests/*_test
 tests/*_tests
 src/config.h
-src/config.h.in
+src/config.h.in*
 src/fir_hilbert_coeffs.h
 src/sndfile-generate-chirp
 src/sndfile-jackplay

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,12 @@
-EXTRA_DIST = README.md Scripts/calc-hilbert-fir.m
+EXTRA_DIST = \
+	README.md \
+	Scripts/calc-hilbert-fir.m
 
-dist_html_DATA = doc/index.html doc/sweep.png doc/wave-example.png doc/wave-sweep.png \
+dist_html_DATA = \
+	doc/index.html \
+	doc/sweep.png \
+	doc/wave-example.png \
+	doc/wave-sweep.png \
 	doc/libsndfile.css
 
 bin_PROGRAMS = \
@@ -12,30 +18,52 @@ bin_PROGRAMS = \
 
 CLEANFILES = src/*~
 
-dist_man_MANS = man/sndfile-generate-chirp.1 man/sndfile-spectrogram.1 \
-	man/sndfile-mix-to-mono.1 man/sndfile-jackplay.1 man/sndfile-resample.1
+dist_man_MANS = \
+	man/sndfile-generate-chirp.1 \
+	man/sndfile-spectrogram.1 \
+	man/sndfile-mix-to-mono.1 \
+	man/sndfile-jackplay.1 \
+	man/sndfile-resample.1
 
 #=========================================================================================
 # The bin targets.
 
-bin_sndfile_generate_chirp_SOURCES = src/generate-chirp.c src/common.c src/common.h
+bin_sndfile_generate_chirp_SOURCES = \
+	src/common.c \
+	src/common.h \
+	src/generate-chirp.c
 bin_sndfile_generate_chirp_CFLAGS = $(SNDFILE_CFLAGS)
 bin_sndfile_generate_chirp_LDADD = $(SNDFILE_LIBS)
 
-bin_sndfile_spectrogram_SOURCES = src/spectrogram.c src/window.c src/common.c \
-	src/window.h src/common.h src/spectrum.c src/spectrum.h
+bin_sndfile_spectrogram_SOURCES = \
+	src/common.c \
+	src/common.h \
+	src/spectrogram.c \
+	src/spectrum.c \
+	src/spectrum.h \
+	src/window.c \
+	src/window.h
 bin_sndfile_spectrogram_CFLAGS = $(SNDFILE_CFLAGS) $(FFTW3_CFLAGS) $(CAIRO_CFLAGS)
 bin_sndfile_spectrogram_LDADD = $(SNDFILE_LIBS) $(FFTW3_LIBS) $(CAIRO_LIBS)
 
-bin_sndfile_mix_to_mono_SOURCES = src/mix-to-mono.c src/common.h src/common.c
+bin_sndfile_mix_to_mono_SOURCES = \
+	src/common.c \
+	src/common.h \
+	src/mix-to-mono.c
 bin_sndfile_mix_to_mono_CFLAGS = $(SNDFILE_CFLAGS)
 bin_sndfile_mix_to_mono_LDADD = $(SNDFILE_LIBS)
 
-bin_sndfile_waveform_SOURCES = src/waveform.c src/common.c src/common.h
+bin_sndfile_waveform_SOURCES = \
+	src/common.c \
+	src/common.h \
+	src/waveform.c
 bin_sndfile_waveform_CFLAGS = $(SNDFILE_CFLAGS) $(CAIRO_CFLAGS)
 bin_sndfile_waveform_LDADD = $(SNDFILE_LIBS) $(CAIRO_LIBS)
 
-bin_sndfile_resample_SOURCES = src/resample.c src/common.c src/common.h
+bin_sndfile_resample_SOURCES = \
+	src/common.c \
+	src/common.h \
+	src/resample.c
 bin_sndfile_resample_CFLAGS = $(SNDFILE_CFLAGS) $(SAMPLERATE_CFLAGS)
 bin_sndfile_resample_LDADD = $(SNDFILE_LIBS) $(SAMPLERATE_LIBS)
 
@@ -50,16 +78,26 @@ endif
 # The make check targets.
 
 # Test programs or programs not yet working.
-check_PROGRAMS = tests/kaiser_window_test tests/common_tests
+check_PROGRAMS = \
+	tests/common_tests \
+	tests/kaiser_window_test
 
-tests_kaiser_window_test_SOURCES = tests/kaiser_window_test.c src/window.h src/window.c
+tests_kaiser_window_test_SOURCES = \
+	src/window.c \
+	src/window.h \
+	tests/kaiser_window_test.c
 
-tests_common_tests_SOURCES = tests/common_tests.c src/common.c src/common.h
+tests_common_tests_SOURCES = \
+	src/common.c \
+	src/common.h \
+	tests/common_tests.c
 tests_common_tests_CFLAGS = $(SNDFILE_CFLAGS)
 tests_common_tests_LDADD = $(SNDFILE_LIBS)
 
 EXTRA_DIST += tests/test-wrapper.sh
-TESTS = tests/kaiser_window_test tests/common_tests tests/test-wrapper.sh
+TESTS = \
+	$(check_PROGRAMS) \
+	tests/test-wrapper.sh
 
 # The 'dist-clean' target on Mac OSX fails without this.
 clean-local:

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# Copyright (C) 2002-2017 Erik de Castro Lopo <erikd@mega-nerd.com>
+# Copyright (C) 2002-2021 Erik de Castro Lopo <erikd@mega-nerd.com>
 
 dnl Require autoconf version >= 2.69)
 AC_PREREQ([2.69])
@@ -42,11 +42,6 @@ AS_IF([test "x$ac_cv_prog_cc_c99" = "xno"], [
 AC_LANG([C])
 AX_COMPILER_VENDOR
 AX_COMPILER_VERSION
-
-AC_PROG_INSTALL
-AC_PROG_MAKE_SET
-AC_PROG_LN_S
-LT_INIT
 
 dnl ====================================================================================
 dnl  Finished checking, handle options.


### PR DESCRIPTION
* Don't invoke `LT_INIT`, we don't use libtool in sndfile-tools.