### PR TITLE
Zero-initialize sfinfo in resample.c to fix Valgrind error

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -31,7 +31,7 @@ const char *font_family = "DejaVu Sans Mono" ;
 sf_count_t
 sfx_mix_mono_read_double (SNDFILE * file, double * data, sf_count_t datalen)
 {
-	SF_INFO info ;
+	SF_INFO info = {} ;
 
 	sf_command (file, SFC_GET_CURRENT_SF_INFO, &info, sizeof (info)) ;
 

--- a/src/generate-chirp.c
+++ b/src/generate-chirp.c
@@ -200,7 +200,7 @@ generate_file (const char * filename, const PARAMS * params)
 {
 	char buffer [1024] ;
 	SNDFILE * file ;
-	SF_INFO info ;
+	SF_INFO info = {} ;
 	double w0, w1 ;
 
 	memset (&info, 0, sizeof (info)) ;

--- a/src/jackplay.c
+++ b/src/jackplay.c
@@ -257,7 +257,7 @@ int
 main (int argc, char * argv [])
 {	pthread_t thread_id ;
 	SNDFILE *sndfile ;
-	SF_INFO sfinfo ;
+	SF_INFO sfinfo = {} ;
 	const char * filename ;
 	jack_client_t *client ;
 	jack_status_t status = 0 ;

--- a/src/mix-to-mono.c
+++ b/src/mix-to-mono.c
@@ -29,7 +29,7 @@ int
 main (int argc, char ** argv)
 {
 	SNDFILE *infile, *outfile ;
-	SF_INFO sfinfo ;
+	SF_INFO sfinfo = {} ;
 
 	if (argc != 3)
 		usage_exit () ;

--- a/src/resample.c
+++ b/src/resample.c
@@ -30,7 +30,7 @@ static double apply_gain (float * data, long frames, int channels, double max, d
 int
 main (int argc, char *argv [])
 {	SNDFILE	*infile, *outfile = NULL ;
-	SF_INFO sfinfo ;
+	SF_INFO sfinfo = {} ;
 	sf_count_t nframes ;
 
 	int normalize = 1 ;

--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -898,7 +898,7 @@ static void
 render_sndfile (RENDER * render)
 {
 	SNDFILE *infile ;
-	SF_INFO info ;
+	SF_INFO info = {} ;
 
 	memset (&info, 0, sizeof (info)) ;
 

--- a/src/waveform.c
+++ b/src/waveform.c
@@ -945,7 +945,7 @@ static void
 render_sndfile (RENDER * render)
 {
 	SNDFILE *infile ;
-	SF_INFO info ;
+	SF_INFO info = {} ;
 	sf_count_t max_width ;
 
 	memset (&info, 0, sizeof (info)) ;


### PR DESCRIPTION
On Fedora 34 x86_64, the `valgrind` checks in `tests/test_wrapper` give:

```
valgrind bin/sndfile-generate-chirp   : ok
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-spectrogram      : 0 errors, 256 bytes leaked
valgrind bin/sndfile-waveform         : 0 errors, 392 bytes leaked
```

This PR zero-initializes the `SF_INFO` structure, which fixes the `sndfile-resample` errors, like the following:

```
==164062== Memcheck, a memory error detector
==164062== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==164062== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==164062== Command: bin/sndfile-resample -to 48000 -c 2 tmp-20210430T120032/chirp.wav tmp-20210430T120032/chirp2.wav
==164062==
==164062== Conditional jump or move depends on uninitialised value(s)
==164062==    at 0x4886E9A: psf_open_file (sndfile.c:2946)
==164062==    by 0x109518: main (resample.c:146)
==164062==
Input File    : tmp-20210430T120032/chirp.wav
Sample Rate   : 44100
Input Frames  : 44100

SRC Ratio     : 1.088435
Converter     : Fastest Sinc Interpolator

Output File   : tmp-20210430T120032/chirp2.wav
Sample Rate   : 48000
 - remaining  :                   0

Output has clipped. Restarting conversion to prevent clipping.

 - remaining  :                   0
Output Frames : 48000

==164062==
==164062== HEAP SUMMARY:
==164062==     in use at exit: 0 bytes in 0 blocks
==164062==   total heap usage: 20 allocs, 20 frees, 150,416 bytes allocated
==164062==
==164062== All heap blocks were freed -- no leaks are possible
==164062==
==164062== Use --track-origins=yes to see where uninitialised values come from
==164062== For lists of detected and suppressed errors, rerun with: -s
==164062== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

The result is:

```
valgrind bin/sndfile-generate-chirp   : ok
valgrind bin/sndfile-resample         : ok
valgrind bin/sndfile-resample         : ok
valgrind bin/sndfile-resample         : ok
valgrind bin/sndfile-spectrogram      : 0 errors, 256 bytes leaked
valgrind bin/sndfile-waveform         : 0 errors, 392 bytes leaked
```