### PR TITLE
Fix a leaked cairo context in render_to_surface() in waveform.c

### DIFF
--- a/src/waveform.c
+++ b/src/waveform.c
@@ -912,6 +912,7 @@ render_to_surface (RENDER * render, SNDFILE *infile, SF_INFO *info, cairo_surfac
 			render_timeaxis (surface, render, info, LEFT_BORDER, width, TOP_BORDER, height) ;
 		} ;
 
+	cairo_destroy (cr) ;
 	return ;
 } /* render_to_surface */
 


### PR DESCRIPTION
On Fedora 34 x86_64, the `valgrind` checks in `tests/test_wrapper` give:

```
valgrind bin/sndfile-generate-chirp   : ok
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-spectrogram      : 0 errors, 256 bytes leaked
valgrind bin/sndfile-waveform         : 0 errors, 392 bytes leaked
```

This PR adds a missing call to `cairo_destroy()` in `render_to_surface()` in `waveform.c` to fix the leak in `sndfile-waveform`:

```
==189578== Memcheck, a memory error detector
==189578== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==189578== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==189578== Command: bin/sndfile-waveform tmp-20210430T125133/chirp.wav tmp-20210430T125133/wavform.png
==189578==
==189578==
==189578== HEAP SUMMARY:
==189578==     in use at exit: 675,260 bytes in 25 blocks
==189578==   total heap usage: 3,412 allocs, 3,387 frees, 16,867,748 bytes allocated
==189578==
==189578== 642,256 (392 direct, 641,864 indirect) bytes in 1 blocks are definitely lost in loss record 25 of 25
==189578==    at 0x484086F: malloc (vg_replace_malloc.c:380)
==189578==    by 0x49260E4: ??? (in /usr/lib64/libcairo.so.2.11704.0)
==189578==    by 0x4926785: cairo_image_surface_create (in /usr/lib64/libcairo.so.2.11704.0)
==189578==    by 0x10AD06: UnknownInlinedFun (waveform.c:925)
==189578==    by 0x10AD06: UnknownInlinedFun (waveform.c:1000)
==189578==    by 0x10AD06: main (waveform.c:1281)
==189578==
==189578== LEAK SUMMARY:
==189578==    definitely lost: 392 bytes in 1 blocks
==189578==    indirectly lost: 641,864 bytes in 4 blocks
==189578==      possibly lost: 0 bytes in 0 blocks
==189578==    still reachable: 33,004 bytes in 20 blocks
==189578==         suppressed: 0 bytes in 0 blocks
==189578== Reachable blocks (those to which a pointer was found) are not shown.
==189578== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==189578==
==189578== For lists of detected and suppressed errors, rerun with: -s
==189578== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

The result is:

```
valgrind bin/sndfile-generate-chirp   : ok
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-resample         : 1 errors, 0 bytes leaked
valgrind bin/sndfile-spectrogram      : 0 errors, 256 bytes leaked
valgrind bin/sndfile-waveform         : ok
```

See also https://github.com/libsndfile/sndfile-tools/pull/74, which fixes the problems with `sndfile-resample`.