### PR TITLE
Expand several man pages and fix missing man page for sndfile-waveform

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,8 @@ dist_man_MANS = \
 	man/sndfile-spectrogram.1 \
 	man/sndfile-mix-to-mono.1 \
 	man/sndfile-jackplay.1 \
-	man/sndfile-resample.1
+	man/sndfile-resample.1 \
+	man/sndfile-waveform.1
 
 #=========================================================================================
 # The bin targets.

--- a/man/sndfile-generate-chirp.1
+++ b/man/sndfile-generate-chirp.1
@@ -1,22 +1,78 @@
-.TH SNDFILE-GENERATE-CHIRP 1 "December 14, 2009"
+.TH SNDFILE\-GENERATE\-CHIRP 1 "May 2021" "" "User Commands"
 .SH NAME
-sndfile-generate-chirp \- generate a sound file containing a chirp
+.B sndfile\-generate\-chirp
+\(em create a sound file containing a swept sine wave
 .SH SYNOPSIS
-.B sndfile-generate-chirp
-.RI "[options] <sample rate> <length in seconds> <sound file>"
-
+.B sndfile\-generate-chirp
+.RB [ OPTIONS ]
+.RI < sample\ rate >
+.RI < length\ in\ seconds >
+.RI < sound\ file >
 .SH DESCRIPTION
-sndfile-generate-chirp generates a sound file containing a sine wave that
-sweeps from a low starting frequency to a higher ending frequency (ie a chirp).
-The file is written using libsndfile (http://www.mega-nerd.com/libsndfile/).
-.LP
-The parameters allows the start and end sine wave frequencies to be set as well
-as specifying the shape of the sweep (ie linear, quadratic or logarithmic).
-Run "sndfile\-generate-chirp \-\-help" for more information.
-.LP
-The format of the output file is determined by the filename extension
-of the output file.
-
-.SH AUTHOR
-This manual page was written by Erik de Castro Lopo <erikd@mega-nerd.com>.
-
+.B sndfile\-generate\-chirp
+generates a sound file containing a sine wave that
+sweeps from a low starting frequency to a higher ending frequency (i.e., a
+chirp).
+The file is written using
+.UR http://www.mega\-nerd.com/libsndfile/
+libsndfile
+.UE .
+.P
+The output file will contain floating point samples in the range
+.BR [\-1.0,\ 1.0] .
+The output file type is determined by the file name extension which should be
+one of
+.BR wav ,
+.BR aifc ,
+.BR aif ,
+.BR aiff ,
+.BR au ,
+.BR caf
+or
+.BR w64 .
+.SH OPTIONS
+.TP
+.B \-from\fR\ \fIstart
+Sweep start frequency in Hz (default 200Hz).
+.TP
+.B \-to\fR\ \fIend
+Sweep end frequency in Hz (default fs/2).
+.TP
+.B \-amp\fR\ \fIvalue
+Amplitude of generated sine (default 1.0).
+.TP
+.I sweep\ type
+One of (default
+.BR \-log ):
+.RS +14n
+.TP
+.B \-log
+logarithmic sweep
+.TP
+.B \-quad
+quadratic sweep
+.TP
+.B \-linear
+linear sweep
+.RE
+.TP
+.BR \-h ,\  \-\-help
+Print a help message and exit.
+.P
+The
+.I length\ in\ seconds
+parameter can be a decimal like
+.BR 0.5 .
+.SH AUTHORS
+This manual page was written by
+.MT erikd@mega-nerd.com
+Erik de Castro Lopo
+.ME
+in 2009.
+It has since been modified and updated by other authors.
+.SH "SEE ALSO"
+.BR sndfile\-jackplay (1),
+.BR sndfile\-mix\-to\-mono (1),
+.BR sndfile\-resample (1),
+.BR sndfile\-spectrogram (1),
+.BR sndfile\-waveform (1)

--- a/man/sndfile-jackplay.1
+++ b/man/sndfile-jackplay.1
@@ -1,15 +1,50 @@
-.TH SNDFILE-JACKPLAY 1 "October 5, 2009"
+.TH SNDFILE\-JACKPLAY 1 "May 2021" "" "User Commands"
 .SH NAME
-sndfile-jackplay \- play a sound file via the JACK sound server
+.B sndfile\-jackplay
+\(em play a sound file via the JACK sound server
 .SH SYNOPSIS
-.B sndfile-jackplay
-.RI "[options] <sound file>"
+.B sndfile\-jackplay
+.RB [ OPTIONS ]
+.RI < input\ sound\ file >
 .SH DESCRIPTION
-sndfile-jackplay plays the specified sound file via the JACK sound server.
-It uses libsndfile (http://www.mega-nerd.com/libsndfile/)
+.B sndfile\-jackplay
+plays the specified sound file via the JACK sound server.
+It uses
+.UR http://www.mega\-nerd.com/libsndfile/
+libsndfile
+.UE
 to read the file.
-.LP
-Run "sndfile-jackplay --help" for information about the options.
-.SH AUTHOR
-This manual page was written by Erik de Castro Lopo <erikd@mega-nerd.com>.
-
+.SH OPTIONS
+.TP
+.BR \-w ,\  \-\-wait [ =\fIport ]
+Wait for input before starting playback; optionally auto-connect to
+.I port
+using Jack.
+.TP
+.BR \-a ,\  \-\-autoconnect [ =\fIport ]
+Auto-connect to
+.I port
+using Jack.
+.TP
+.BR \-l ,\  \-\-loop [ =\fIcount ]
+Loop the file
+.I count
+times
+.RB ( 0
+for infinite).
+.TP
+.BR \-h ,\  \-\-help
+Print a help message and exit.
+.SH AUTHORS
+This manual page was written by
+.MT erikd@mega-nerd.com
+Erik de Castro Lopo
+.ME
+in 2009.
+It has since been modified and updated by other authors.
+.SH "SEE ALSO"
+.BR sndfile\-generate\-chirp (1),
+.BR sndfile\-mix\-to\-mono (1),
+.BR sndfile\-resample (1),
+.BR sndfile\-spectrogram (1),
+.BR sndfile\-waveform (1)

--- a/man/sndfile-mix-to-mono.1
+++ b/man/sndfile-mix-to-mono.1
@@ -1,20 +1,37 @@
-.TH SNDFILE-MIX-TO-MONO 1 "December 14, 2009"
+.TH SNDFILE\-MIX\-TO\-MONO 1 "May 2021" "" "User Commands"
 .SH NAME
-sndfile-mix-to-mono \- mix a multi\-channel sound file to mono
+.B sndfile\-mix\-to\-mono
+\(em mix a multi-channel sound file to mono
 .SH SYNOPSIS
-.B sndfile-mix-to-mono
-.RI "<multi-channel input file> <mono output file>"
-
+.B sndfile\-mix\-to\-mono
+.RI < multi\-channel\ input\ file >
+.RI < mono\ output\ file >
 .SH DESCRIPTION
-sndfile\-mix\-to\-mono reads a multi\-channel input file and writes a single
-channel output file consisting of all of the input channels mixed together
-(like a audio mixing desk would do).
-The input and output files are read/written using libsndfile
-(http://www.mega\-nerd.com/libsndfile/).
+.B sndfile\-mix\-to\-mono
+reads a multi-channel input file and writes a single-channel output file
+consisting of all of the input channels mixed together (like an audio mixing
+desk would do).
+The input and output files are read/written using
+.UR http://www.mega\-nerd.com/libsndfile/
+libsndfile
+.UE .
 .LP
 The format of the output file is determined by the filename extension
 of the output file.
-
-.SH AUTHOR
-This manual page was written by Erik de Castro Lopo <erikd@mega-nerd.com>.
-
+.SH OPTIONS
+.TP
+.BR \-h ,\  \-\-help
+Print a help message and exit.
+.SH AUTHORS
+This manual page was originally written by
+.MT erikd@mega-nerd.com
+Erik de Castro Lopo
+.ME
+in 2009.
+It has since been modified and updated by other authors.
+.SH "SEE ALSO"
+.BR sndfile\-generate\-chirp (1),
+.BR sndfile\-jackplay (1),
+.BR sndfile\-resample (1),
+.BR sndfile\-spectrogram (1),
+.BR sndfile\-waveform (1)

--- a/man/sndfile-spectrogram.1
+++ b/man/sndfile-spectrogram.1
@@ -1,24 +1,84 @@
-.TH SNDFILE-SPECTROGRAM 1 "December 14, 2009"
+.TH SNDFILE\-SPECTROGRAM 1 "May 2021" "" "User Commands"
 .SH NAME
-sndfile-spectrogram \- generate a spectrogram from an input sound file
+.B sndfile\-spectrogram
+\(em generate a spectrogram from an input sound file
 .SH SYNOPSIS
-.B sndfile-spectrogram
-.RI "[options] <sound file> <img width> <img height> <png name>"
-
+.B sndfile\-spectrogram
+.RB [ OPTIONS ]
+.RI < sound\ file >
+.RI < img\ width >
+.RI < img\ height >
+.RI < png\ name >
 .SH DESCRIPTION
-sndfile\-spectrogram reads a single channel sound file and generates a
-spectrogram which is written to a PNG file with specified image height
-and width.
-.LP
-The optional parameters allow the user to specify the dynamic range of
-the spectrogram plot and/or to disable the drawing of borders, scales,
-heat map and title.
-Run "sndfile\-spectrogram \-\-help" for more information.
-.LP
-The input file is read using libsndfile (http://www.mega\-nerd.com/libsndfile/),
-the spectrogram is calculated with the help of libfftw and the spectrogram is
-rendered and written to the output file using libcairo.
-
-.SH AUTHOR
-This manual page was written by Erik de Castro Lopo <erikd@mega-nerd.com>.
-
+Create a spectrogram as a PNG file from a given sound file.
+The spectrogram image will be of the given width and height.
+.P
+The input file is read using
+.UR http://www.mega\-nerd.com/libsndfile/
+libsndfile
+.UE ,
+the spectrogram is calculated with the help of
+.UR http://fftw.org/
+FFTW
+.UE ,
+and the spectrogram is
+rendered and written to the output file using
+.UR https://www.cairographics.org/
+libcairo
+.UE .
+.SH OPTIONS
+.TP
+.BI \-\-dyn\-range= number
+Dynamic range (default is
+.B 180
+for 180dB range)
+.TP
+.B \-\-no\-border
+Drop the border, scales, heat map and title
+.TP
+.BI \-\-min\-freq= number
+Set the minimum frequency in the output
+.TP
+.BI \-\-max\-freq= number
+Set the maximum frequency in the output
+.TP
+.BI \-\-fft\-freq= number
+Set the lowest resolvable frequency and the height of each band in the linear
+spectrogram.
+Lower values increase frequency resolution but smear the output horizontally
+and higher values improve the temporal definition but decrease the distinction
+between the lowest frequencies.
+.TP
+.B \-\-log\-freq
+Use a logarithmic frequency scale
+.TP
+.B \-\-gray\-scale
+Output gray pixels instead of a heat map
+.TP
+.B \-\-kaiser
+Use a Kaiser window function (the default)
+.TP
+.B \-\-rectangular
+Use a rectangular window function
+.TP
+.B \-\-nuttall
+Use a Nuttall window function
+.TP
+.B \-\-hann
+Use a Hann window function
+.TP
+.BR \-h ,\  \-\-help
+Print a help message and exit.
+.SH AUTHORS
+This manual page was originally written by
+.MT erikd@mega-nerd.com
+Erik de Castro Lopo
+.ME
+in 2009.
+It has since been modified and updated by other authors.
+.SH "SEE ALSO"
+.BR sndfile\-generate\-chirp (1),
+.BR sndfile\-jackplay (1),
+.BR sndfile\-mix\-to\-mono (1),
+.BR sndfile\-resample (1),
+.BR sndfile\-waveform (1)


### PR DESCRIPTION
Expand the man pages for:

- `sndfile-generate-chirp`
- `sndfile-jackplay`
- `sndfile-mix-to-mono`
- `sndfile-spectrogram`

to be at least as useful as their --help output.

-----

I saw that there is a man page for `sndfile-waveform`, contrary to my claim in https://github.com/libsndfile/sndfile-tools/issues/77, but it is not included in the release tarball, so I fixed that in this PR too. (`sndfile-waveform.1` was missing from `dist_man_MANS` in `Makefile.am`; the fix may be obsolete soon, as it looks like the project is switching to CMake, and `sndfile-waveform.1` is not missing from `SNDFILE_TOOLS_MANS` in `CMakeLists.txt`.)

-----

I did not touch the man page for `sndfile-resample`, since it is relatively recently updated and in good condition.

The man pages I updated were, and are, in `-man` format, `groff_man(7)`; the man page for `sndfile-resample` is in `-mdoc` format, `groff_mdoc(7)`; and the man page for `sndfile-waveform` is generated by `help2man`. This mixture is unfortunate, but I’m not proposing to change it, as:

- I did not want to write `-mdoc` format from scratch or set up the command output for `help2man` for the man pages I updated.
- The other two man pages are already complete and apparently maintaned, so it would be presumptuous of me to rewrite them just to match my preferred format.