### PR TITLE
Remove memset()s made redundant by C99-style zero-initializations

### DIFF
--- a/src/generate-chirp.c
+++ b/src/generate-chirp.c
@@ -203,8 +203,6 @@ generate_file (const char * filename, const PARAMS * params)
 	SF_INFO info = {} ;
 	double w0, w1 ;
 
-	memset (&info, 0, sizeof (info)) ;
-
 	info.format = params->format ;
 	info.samplerate = params->samplerate ;
 	info.channels = 1 ;

--- a/src/jackplay.c
+++ b/src/jackplay.c
@@ -320,7 +320,6 @@ main (int argc, char * argv [])
 		} ;
 
 	/* Open the soundfile. */
-	memset (&sfinfo, 0, sizeof (sfinfo)) ;
 	sndfile = sf_open (filename, SFM_READ, &sfinfo) ;
 	if (sndfile == NULL)
 	{	fprintf (stderr, "Could not open soundfile '%s'\n", filename) ;

--- a/src/mix-to-mono.c
+++ b/src/mix-to-mono.c
@@ -39,7 +39,6 @@ main (int argc, char ** argv)
 		exit (1) ;
 		} ;
 
-	memset (&sfinfo, 0, sizeof (sfinfo)) ;
 	if ((infile = sf_open (argv [argc - 2], SFM_READ, &sfinfo)) == NULL)
 	{	printf ("Error : Not able to open input file '%s'\n", argv [argc - 2]) ;
 		sf_close (infile) ;

--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -900,8 +900,6 @@ render_sndfile (RENDER * render)
 	SNDFILE *infile ;
 	SF_INFO info = {} ;
 
-	memset (&info, 0, sizeof (info)) ;
-
 	infile = sf_open (render->sndfilepath, SFM_READ, &info) ;
 	if (infile == NULL)
 	{	printf ("Error : failed to open file '%s' : \n%s\n", render->sndfilepath, sf_strerror (NULL)) ;

--- a/src/waveform.c
+++ b/src/waveform.c
@@ -949,8 +949,6 @@ render_sndfile (RENDER * render)
 	SF_INFO info = {} ;
 	sf_count_t max_width ;
 
-	memset (&info, 0, sizeof (info)) ;
-
 	infile = sf_open (render->sndfilepath, SFM_READ, &info) ;
 	if (infile == NULL)
 	{	printf ("Error: failed to open file '%s': \n%s\n", render->sndfilepath, sf_strerror (NULL)) ;


### PR DESCRIPTION
Remove `memset()`s made redundant by C99-style zero-initializations added in 3d91cc9abea5745d9814e501a8a5b3cba3497f70