### PR TITLE
Adjust whitespace to pacify Scripts/cstyle.py

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -31,7 +31,7 @@ const char *font_family = "DejaVu Sans Mono" ;
 sf_count_t
 sfx_mix_mono_read_double (SNDFILE * file, double * data, sf_count_t datalen)
 {
-	SF_INFO info = {} ;
+	SF_INFO info = { } ;
 
 	sf_command (file, SFC_GET_CURRENT_SF_INFO, &info, sizeof (info)) ;
 

--- a/src/generate-chirp.c
+++ b/src/generate-chirp.c
@@ -200,7 +200,7 @@ generate_file (const char * filename, const PARAMS * params)
 {
 	char buffer [1024] ;
 	SNDFILE * file ;
-	SF_INFO info = {} ;
+	SF_INFO info = { } ;
 	double w0, w1 ;
 
 	info.format = params->format ;

--- a/src/jackplay.c
+++ b/src/jackplay.c
@@ -257,7 +257,7 @@ int
 main (int argc, char * argv [])
 {	pthread_t thread_id ;
 	SNDFILE *sndfile ;
-	SF_INFO sfinfo = {} ;
+	SF_INFO sfinfo = { } ;
 	const char * filename ;
 	jack_client_t *client ;
 	jack_status_t status = 0 ;

--- a/src/mix-to-mono.c
+++ b/src/mix-to-mono.c
@@ -29,7 +29,7 @@ int
 main (int argc, char ** argv)
 {
 	SNDFILE *infile, *outfile ;
-	SF_INFO sfinfo = {} ;
+	SF_INFO sfinfo = { } ;
 
 	if (argc != 3)
 		usage_exit () ;

--- a/src/resample.c
+++ b/src/resample.c
@@ -30,7 +30,7 @@ static double apply_gain (float * data, long frames, int channels, double max, d
 int
 main (int argc, char *argv [])
 {	SNDFILE	*infile, *outfile = NULL ;
-	SF_INFO sfinfo = {} ;
+	SF_INFO sfinfo = { } ;
 	sf_count_t nframes ;
 
 	int normalize = 1 ;
@@ -233,8 +233,8 @@ sample_rate_convert (SNDFILE *infile, SNDFILE *outfile, int converter, double sr
 	double		max = 0.0 ;
 	sf_count_t	output_count = 0 ;
 
-	char		anim[4] = "-\\|/" ;
-	short		p_anim = 0;
+	char		anim [4] = "-\\|/" ;
+	short		p_anim = 0 ;
 
 	sf_seek (infile, 0, SEEK_SET) ;
 	sf_seek (outfile, 0, SEEK_SET) ;
@@ -285,11 +285,11 @@ sample_rate_convert (SNDFILE *infile, SNDFILE *outfile, int converter, double sr
 
 		src_data.data_in += src_data.input_frames_used * channels ;
 		src_data.input_frames -= src_data.input_frames_used ;
-		nframes-=src_data.input_frames_used;
-		printf(" %c remaining  : %19li\r", anim[p_anim], nframes);
-		p_anim=(p_anim + 1) % 4;
+		nframes -= src_data.input_frames_used ;
+		printf (" %c remaining  : %19li\r", anim [p_anim], nframes) ;
+		p_anim = (p_anim + 1) % 4 ;
 		} ;
-	printf("\n");
+	printf ("\n") ;
 
 	src_delete (src_state) ;
 

--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -252,7 +252,7 @@ y_line (cairo_t * cr, double x, double y, double len)
 ** Search for "worst case" for the commentary below that says why it is 35.
 */
 typedef struct
-{	double value [40] ;  /* 35 or more */
+{	double value [40] ;	/* 35 or more */
 	double distance [40] ;
 	/* The digit that changes from label to label.
 	** This ensures that a range from 999 to 1001 prints 999.5 and 1000.5
@@ -898,7 +898,7 @@ static void
 render_sndfile (RENDER * render)
 {
 	SNDFILE *infile ;
-	SF_INFO info = {} ;
+	SF_INFO info = { } ;
 
 	infile = sf_open (render->sndfilepath, SFM_READ, &info) ;
 	if (infile == NULL)

--- a/src/waveform.c
+++ b/src/waveform.c
@@ -946,7 +946,7 @@ static void
 render_sndfile (RENDER * render)
 {
 	SNDFILE *infile ;
-	SF_INFO info = {} ;
+	SF_INFO info = { } ;
 	sf_count_t max_width ;
 
 	infile = sf_open (render->sndfilepath, SFM_READ, &info) ;


### PR DESCRIPTION
About half of these deviations from the prescribed style were introduced in my recent PR’s. (Pre-commit hooks were not working for me at the time, and I had not noticed the style checker script.) The rest were pre-existing.

I’m still ignoring the pre-commit hook that asks me to add my name to the copyright headers, because (in my view) my PR’s to date have been trivial and not subject to copyright protection.