### PR TITLE
mix-to-mono: don't remove the output

### DIFF
--- a/src/mix-to-mono.c
+++ b/src/mix-to-mono.c
@@ -60,9 +60,6 @@ main (int argc, char ** argv)
 		exit (1) ;
 		} ;
 
-	/* Delete the output file length to zero if already exists. */
-	remove (argv [argc - 1]) ;
-
 	mix_to_mono (infile, outfile) ;
 
 	sf_close (infile) ;


### PR DESCRIPTION
Currently, mix-to-mono removes the named output file for no reason.
Removing the output file is baaaad, mkay, so don't do that.
This fixes https://github.com/libsndfile/sndfile-tools/issues/87