### PR TITLE
Add time-stretching option to sndfile-resample

### DIFF
--- a/man/sndfile-resample.1
+++ b/man/sndfile-resample.1
@@ -7,11 +7,13 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl c Ar number
+.Op Fl s Ar ratio
 .Fl to Ar rate
 .Ar input
 .Ar output
 .Nm
 .Op Fl c Ar number
+.Op Fl s Ar ratio
 .Fl by Ar ratio
 .Ar input
 .Ar output
@@ -50,6 +52,12 @@ For instance, changing the rate of 44100 by a factor of 1.3333
 results in a sample rate of 58798.
 .It Fl -no-normalize
 Disable clipping check and normalization.
+.It Fl s Ar ratio
+Specifies a time stretch ratio to apply to the sample data.  This value
+can be used to adjust the playback speed of the file, to perform
+time-stretching operations.  Values greater than 1.0 increase the time
+and decrease the speed.  Values less than 1.0 decrease the time and
+increase the speed.
 .El
 .Sh SEE ALSO
 .Lk http://www.mega-nerd.com/libsndfile/

--- a/src/resample.c
+++ b/src/resample.c
@@ -37,6 +37,7 @@ main (int argc, char *argv [])
 	sf_count_t	count ;
 	double		src_ratio = -1.0, gain = 1.0 ;
 	int			new_sample_rate = -1, k, converter, max_speed = SF_FALSE, raw_bits ;
+	double		stretch_ratio = 0.0;
 	char		raw_type ;
 
 	if (argc == 2 && strcmp (argv [1], "--version") == 0)
@@ -126,6 +127,10 @@ main (int argc, char *argv [])
 				usage_exit (argv [0]) ;
 				}
 			}
+		else if (strcmp (argv [k], "-s") == 0)
+		{	k ++ ;
+			stretch_ratio = atof (argv [k]) ;
+			}
 		else
 			usage_exit (argv [0]) ;
 		} ;
@@ -166,6 +171,9 @@ main (int argc, char *argv [])
 		exit (1) ;
 		} ;
 
+	if (stretch_ratio > 0.0)
+		src_ratio = src_ratio * stretch_ratio ;
+
 	if (fabs (src_ratio - 1.0) < 1e-20)
 	{	printf ("Target samplerate and input samplerate are the same. Exiting.\n") ;
 		sf_close (infile) ;
@@ -186,6 +194,9 @@ main (int argc, char *argv [])
 
 	printf ("Output File   : %s\n", argv [argc - 1]) ;
 	printf ("Sample Rate   : %d\n", sfinfo.samplerate) ;
+
+	if (stretch_ratio > 0.0)
+		printf ("Stretch Ratio : %f\n", stretch_ratio) ;
 
 	do
 	{	sf_close (outfile) ;
@@ -364,6 +375,14 @@ usage_exit (const char *progname)
 		"  or 'f' (as float) and BB the bits per sample (8, 16, ...)\n"
 		"  Note: when raw audio input is used, then a raw output audio file will be\n"
 		"  created as well.") ;
+
+	puts ("\n"
+		"  The optional -s argument specifies a time stretch ratio to apply to the\n"
+		"  sample data.  This value can be used to adjust the playback speed of the\n"
+		"  file, to perform time-stretching operations.  Values greater than 1.0\n"
+		"  increase the time and decrease the speed.  Values less than 1.0 decrease\n"
+		"  the time and increase the speed."
+		) ;
 
 	puts ("") ;
 

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -51,6 +51,7 @@ testwrap bin/sndfile-generate-chirp 44100 1 $tmpdir/chirp.wav
 testwrap bin/sndfile-resample -to 48000 -c 2 $tmpdir/chirp.wav $tmpdir/chirp2.wav
 testwrap bin/sndfile-resample -to 48000 -c 3 $tmpdir/chirp.wav $tmpdir/chirp2.wav
 testwrap bin/sndfile-resample -to 48000 -c 4 $tmpdir/chirp.wav $tmpdir/chirp2.wav
+testwrap bin/sndfile-resample -to 48000 -c 2 -s 1.088435 $tmpdir/chirp.wav $tmpdir/chirp2.wav
 testwrap bin/sndfile-spectrogram $tmpdir/chirp.wav 640 480 $tmpdir/chirp.png
 testwrap bin/sndfile-waveform $tmpdir/chirp.wav $tmpdir/wavform.png
 


### PR DESCRIPTION
- Added -s option to resample.c.  This specifies a floating-point stretch ratio for the audio content, that can be used to adjust the playback speed and length of the file, to perform time-stretching operations.
- Documented -s in sndfile-resample.1.
- Added test case to test-wrapper.sh that uses the -s option.